### PR TITLE
Adjust colors after rebranding update

### DIFF
--- a/app/javascript/src/stylesheets/needs.scss
+++ b/app/javascript/src/stylesheets/needs.scss
@@ -31,15 +31,16 @@ ul.social_workers {
     color: $white;
     border-radius: $global-radius;
     &.claimed {
-      background-color:lighten($secondary-color, 15%);
+      background-color: $secondary-color;
+      color: $primary-color;
     }
     &.unclaimed {
       background-color: $success-color;
     }
     &.add-shift {
-      color: lighten($secondary-color, 15%);
+      color: $primary-color;
       background-color: $white;
-      border: 1px dashed lighten($secondary-color, 15%);
+      border: 1px dashed $primary-color;
     }
   }
 }


### PR DESCRIPTION
This fixes an issue where some shifts would not be visible because the text is white on a white background.

I suspect we may have another issue or two like this that needs to be resolved.