### PR TITLE
Updated docker-compose codespace to reference workspace rather than app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+# ignore plugin local-history
+.history/

--- a/docker-compose.codespaces.yml
+++ b/docker-compose.codespaces.yml
@@ -12,7 +12,7 @@ services:
         - UID=${UID:-1000}
         - GID=${GID:-1000}
     volumes:
-      - .:/app
+      - .:/workspaces/scheduler
       - gems:/gems
     user: ruby
     tty: true


### PR DESCRIPTION
This fixes the issue, where when initializing workspace within the docker container for the first time, docker-compose.codespace.yml reference the volume /app rather than /workspace/scheduler. So the working terminal does not start in the root directory.