### PR TITLE
Updated config initializer for sidekiq to use #load_from_array

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -12,16 +12,17 @@ end
 
 if Rails.env.production?
   CRONJOBS = [
-  {
-    'name'  => 'Reminders',
-    'class' => 'RemindWorker',
-    'cron'  => '0 9-20 * * *',
-  },
-  {
-    'name'  => 'Shift Surveys',
-    'class' => 'ShiftSurveyWorker',
-    'cron'  => '0 5,20,35,50 * ? * *'
-  }]
+    {
+      'name'  => 'Reminders',
+      'class' => 'RemindWorker',
+      'cron'  => '0 9-20 * * *'
+    },
+    {
+      'name'  => 'Shift Surveys',
+      'class' => 'ShiftSurveyWorker',
+      'cron'  => '0 5,20,35,50 * ? * *'
+    }
+  ]
 
-  Sidekiq::Cron::Job.load_from_array! CRONJOBS
+  Sidekiq::Cron::Job.load_from_array!(CRONJOBS)
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,5 @@
 # # frozen_string_literal: true
+
 redis_url = Rails.application.credentials.redis_url || ENV['REDIS_URL']
 
 Sidekiq.configure_client do |config|
@@ -10,16 +11,17 @@ Sidekiq.configure_server do |config|
 end
 
 if Rails.env.production?
-  ActiveSupport.on_load(:active_record) do
-    unless Sidekiq::Cron::Job.find('Reminders')
-      Sidekiq::Cron::Job.create(
-        name: 'Reminders', cron: '0 9-20 * * *', class: 'RemindWorker'
-      )
-    end
-    unless Sidekiq::Cron::Job.find('Shift Surveys')
-      Sidekiq::Cron::Job.create(
-        name: 'Shift Surveys', cron: '0 5,20,35,50 * ? * *', class: 'ShiftSurveyWorker'
-      )
-    end
-  end
+  CRONJOBS = [
+  {
+    'name'  => 'Reminders',
+    'class' => 'RemindWorker',
+    'cron'  => '0 9-20 * * *',
+  },
+  {
+    'name'  => 'Shift Surveys',
+    'class' => 'ShiftSurveyWorker',
+    'cron'  => '0 5,20,35,50 * ? * *'
+  }]
+
+  Sidekiq::Cron::Job.load_from_array! CRONJOBS
 end


### PR DESCRIPTION
This fixes the issue, where shift surveys were not being sent due to https://github.com/fosterful/scheduler/blob/abc31a7903ef659ab628f74da68a008a8c9d0af9/config/initializers/sidekiq.rb#L19 returning an empty job instead of nil, preventing the creation of the cron job.

All test passed with Rspec, but still getting 66.67% coverage with Spring.

The neat thing about the implementation is that, if the jobs do not exist, they are created, if they already exist they are updated and if there are jobs running, it will remove them if not present in the given array.

This closes Issue #806