### PR TITLE
Fix Shift Surveys cron schedule

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -20,7 +20,7 @@ if Rails.env.production?
     {
       'name'  => 'Shift Surveys',
       'class' => 'ShiftSurveyWorker',
-      'cron'  => '0 5,20,35,50 * ? * *'
+      'cron'  => '*/5 * * * *'
     }
   ]
 


### PR DESCRIPTION
As it turns out, '0 5,20,35,50 * ? * *' is not a valid cron expression. This has been wrong since it was committed last year.

We improved the shift selection process such that it doesn't matter how frequently we run the job. So, I've simplified it to every 5 minutes here.