### PR TITLE
Created Demo ENV and fixed env staging to reference url as ENV vars

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -63,8 +63,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: 'app-staging.fosterful.org' }
-  Rails.application.routes.default_url_options = { host: 'app-staging.fosterful.org' }
+  config.action_mailer.default_url_options = { host: ENV['APP_URL'] }
+  Rails.application.routes.default_url_options = { host: ENV['APP_URL'] }
   # Setup the mailer config
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true


### PR DESCRIPTION
Fixed url references staging, by switching to ENV var the url can be set at each Heroku environment.

Closes #819 