### PR TITLE
Remove proof of vax message

### DIFF
--- a/app/lib/services/notifications/shifts/message/update.rb
+++ b/app/lib/services/notifications/shifts/message/update.rb
@@ -47,7 +47,7 @@ module Services
 
           def shift_assigned
             if current_user.require_covid_19_vaccinated?
-              "Thank You! Please be ready to show proof of vaccination at the door. See you soon."
+              "Thanks for your help. See you soon!"
             else
               "You have been assigned a shift #{starting_day} from "\
               "#{duration_in_words}."

--- a/spec/lib/services/notifications/shifts/message/update_spec.rb
+++ b/spec/lib/services/notifications/shifts/message/update_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Services::Notifications::Shifts::Message::Update do
 
           result = object.message
 
-          expect(result).to eql('Thank You! Please be ready to show proof of vaccination at the door. See you soon.')
+          expect(result).to eql('Thanks for your help. See you soon!')
           expect(result).to be_frozen
         end
       end


### PR DESCRIPTION
Quick adjustment to remove the proof of vaccination message.