### PR TITLE
Fix redis SSL error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,7 @@ class ApplicationController < ActionController::Base
 
   def redis
     @redis ||= begin
-      redis_connection = Redis.new(url: Rails.application.credentials.redis_url || ENV['REDIS_URL'])
+      redis_connection = Redis.new(url: Rails.application.credentials.redis_url || ENV['REDIS_URL'], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE })
       Redis::Namespace.new(Rails.env, redis: redis_connection)
     end
   end


### PR DESCRIPTION
Per the Heroku docs, they use self-signed certs.

https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-rails