### PR TITLE
Upgrade selective-ruby-core to 0.1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,7 +380,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selective-ruby-core (0.1.1-x86_64-linux)
+    selective-ruby-core (0.1.2-x86_64-linux)
       zeitwerk (~> 2.6.12)
     selective-ruby-rspec (0.1.0)
       selective-ruby-core


### PR DESCRIPTION
Bump to the latest version of selective-ruby-core.